### PR TITLE
Fix code noncompiling on linux machines

### DIFF
--- a/Dusk2Dawn.cpp
+++ b/Dusk2Dawn.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "Arduino.h"
-#include <Math.h>
+#include <math.h>
 #include "Dusk2Dawn.h"
 
 

--- a/Dusk2Dawn.h
+++ b/Dusk2Dawn.h
@@ -8,7 +8,7 @@
 #define Dusk2Dawn_h
 
   #include "Arduino.h"
-  #include <Math.h>
+  #include <math.h>
 
   class Dusk2Dawn {
     public:


### PR DESCRIPTION
I guess you are using Windows and since it treats filenames and paths in case insensitive manner your code works. This however doesn't apply to Linux. Also afaik C/C++ standards define header as `<math.h>` (lowercase).