### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,4 +1,4 @@
-Dusk2Dawn KEYWORD1
-sunrise   KEYWORD2
-sunset    KEYWORD2
-min2str   KEYWORD2
+Dusk2Dawn	KEYWORD1
+sunrise	KEYWORD2
+sunset	KEYWORD2
+min2str	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords