### PR TITLE
Correct filename in library.properties includes

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Given some basic data, such as geographic coordinates and a date, an e
 category=Other
 url=https://github.com/dmkishi/Dusk2Dawn
 architectures=*
-includes=math.h
+includes=Dusk2Dawn.h


### PR DESCRIPTION
The library.properties `includes` property is used to automatically add the include for the library when the user selects **Sketch > Include Library > Dusk2Dawn**. Thus the previous `includes` property value of `math.h` was incorrect.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format