### PR TITLE
Fix for incorrect minutes returned by min2str

### DIFF
--- a/Dusk2Dawn.cpp
+++ b/Dusk2Dawn.cpp
@@ -59,7 +59,7 @@ bool Dusk2Dawn::min2str(char *str, int minutes) {
    float floatHour   = minutes / 60.0;
    float floatMinute = 60.0 * (floatHour - floor(floatHour));
    byte  byteHour    = (byte) floatHour;
-   byte  byteMinute  = (byte) floatMinute;
+   byte  byteMinute  = (byte) (floatMinute + .5);
 
    if (byteMinute > 59) {
      byteHour   += 1;


### PR DESCRIPTION
this fixes the issue where the minutes are sometimes incorrectly calculated low by 1 minute.

in the example file, the laSunset is at 1004 minutes after midnight, which is 16:54.  However min2str returns 16:53 which is 1 minute low.  This is due to the truncating of the floatMinute value past the decimal point when it is cast as a byte.  The way to fix this is to "force" the rounding of the floatMinute value by adding 0.5 then truncating the value by casting it to a byte.