### PR TITLE
Fractional timezones

### DIFF
--- a/Dusk2Dawn.h
+++ b/Dusk2Dawn.h
@@ -18,7 +18,7 @@
       static bool min2str(char*, int);
     private:
       float _latitude, _longitude;
-      int   _timezone;
+      float    _timezone;
       int   sunriseSet(bool, int, int, int, bool);
       float sunriseSetUTC(bool, float, float, float);
       float equationOfTime(float);

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This fork is to fix the type of the variable _timezone to float. This will allow the management of fractional timezone in the Sunfy328 project.  
+This fork is to fix the type of the variable _timezone to float. This will allow the management of fractional timezones in the Sunfy328 project.  
 https://github.com/Ipposnif/Sunfy328  
   
 ==============================================================================

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+This fork is to fix the type of the variable _timezone to float. This will allow the management of fractional timezone in the Sunfy328 project.  
+https://github.com/Ipposnif/Sunfy328  
+  
+==============================================================================
 # Dusk2Dawn
 
 Minimal Arduino library for sunrise and sunset time.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This fork is to fix the type of the variable _timezone to float. This will allow the management of fractional timezones in the Sunfy328 project.  
+This fork is to change the type of the variable _timezone to float. This fix allows the management of fractional timezones in the Sunfy328 project.  
 https://github.com/Ipposnif/Sunfy328  
   
 ==============================================================================


### PR DESCRIPTION
Actually, it is not possible to calculate dusk and dawn for fractional timezones.
This because the main constructor (Dusk2Dawn) is correctly accepting fractional timezones, but the variable that keeps the timezone (_timezone) is an integer.
To fix this, it is enough to change the type of the variable from integer to float.